### PR TITLE
Replace an apostrophe; fix some line breaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # proofs
 
-These texts are proofs that I created for evaluating typefaces in development. As an alternative to full-alphabet pangram sentences, such as “the quick brown fox jumps over the lazy dog,” these proofs offer a more scientific context for every letter, making it easier to isolate and diagnose problems with a letterform's shape, color, or fit. You’ll find more information about these proofs, along with instructions how to use them, here:
+These texts are proofs that I created for evaluating typefaces in development. As an alternative to full-alphabet pangram sentences, such as “the quick brown fox jumps over the lazy dog,” these proofs offer a more scientific context for every letter, making it easier to isolate and diagnose problems with a letterform’s shape, color, or fit. You’ll find more information about these proofs, along with instructions how to use them, here:
 
 https://www.typography.com/blog/text-for-proofing-fonts
 
 
-Jonathan Hoefler
-Hoefler&Co.
+Jonathan Hoefler<br>
+Hoefler&Co.<br>
 19 May 2020


### PR DESCRIPTION
Specifically for the line breaks, Markdown ignores intra-paragraph line breaks, so the signature was showing as one long line in the rendered version.  Markdown supports standard line breaks by adding two trailing spaces to the end of the line, but this invisible signaling is easy to miss and/or accidentally erase, so I opted to use explicit `<br>`s instead (also supported by Markdown).